### PR TITLE
fix: catch background runtime exceptions

### DIFF
--- a/src/android/WebViewService.java
+++ b/src/android/WebViewService.java
@@ -66,7 +66,12 @@ public class WebViewService extends Service {
             // Claim service is running
             setPreference(JSBackgroundServicePlugin.PREF_SERVICE_RUNNING, true);
 
-            loadUrl();
+            try {
+                loadUrl();
+            }
+            catch (RuntimeException e) {
+                Log.e("Cozy Drive", "exception", e);                
+            }
         }
         return START_NOT_STICKY;
     }


### PR DESCRIPTION
We've started seeing runtime exceptions happen here, and since they aren't caught the whole app crashes. I don't know a reliable way to reproduce the problem, and no intelligent thing to do with the exception.